### PR TITLE
feat: add github-misc-scripts for dependabot configuration

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -53,3 +53,5 @@ repos:
     topics: 'github,github-settings,settings-sync'
     dependabot-yml: './config/dependabot/actions.yml'
   - repo: joshjohanning/hsa-expense-analyzer-cli
+  - repo: joshjohanning/github-misc-scripts
+    dependabot-yml: './config/dependabot/actions.yml'


### PR DESCRIPTION
This pull request adds a new repository to the `repos.yml` configuration file. The new repository, `joshjohanning/github-misc-scripts`, is now included and configured to use the same Dependabot settings as the others.

* Repository Management:
  * Added `joshjohanning/github-misc-scripts` to the list of managed repositories in `repos.yml`, with Dependabot configuration pointing to `./config/dependabot/actions.yml`
