### PR TITLE
chore: add dependabot configuration for hsa-expense-analyzer-cli

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -53,5 +53,6 @@ repos:
     topics: 'github,github-settings,settings-sync'
     dependabot-yml: './config/dependabot/actions.yml'
   - repo: joshjohanning/hsa-expense-analyzer-cli
+    dependabot-yml: './config/dependabot/npm-actions.yml'
   - repo: joshjohanning/github-misc-scripts
     dependabot-yml: './config/dependabot/actions.yml'


### PR DESCRIPTION
This pull request makes a minor update to the `repos.yml` configuration file, specifically for the `joshjohanning/hsa-expense-analyzer-cli` repository. The change updates the path for its Dependabot configuration.