### PR TITLE
feat: update commit message prefixes for dependabot configurations

### DIFF
--- a/config/dependabot/actions.yml
+++ b/config/dependabot/actions.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: 'weekly'
     commit-message:
-      prefix: 'ci'
+      prefix: 'ci(deps)'
     groups:
       github-actions:
         patterns:

--- a/config/dependabot/npm-actions-no-octokit.yml
+++ b/config/dependabot/npm-actions-no-octokit.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: 'weekly'
     commit-message:
-      prefix: 'ci'
+      prefix: 'ci(deps)'
     groups:
       github-actions:
         patterns:
@@ -20,8 +20,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    versioning-strategy: increase
     commit-message:
       prefix: 'chore'
+      include: 'scope'
     groups:
       eslint:
         patterns:

--- a/config/dependabot/npm-actions.yml
+++ b/config/dependabot/npm-actions.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: 'weekly'
     commit-message:
-      prefix: 'ci'
+      prefix: 'ci(deps)'
     groups:
       github-actions:
         patterns:
@@ -20,8 +20,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    versioning-strategy: increase
     commit-message:
       prefix: 'chore'
+      include: 'scope'
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Commit message improvements:

* Changed the commit message prefix for GitHub Actions updates from `'ci'` to `'ci(deps)'` in `config/dependabot/actions.yml`, `config/dependabot/npm-actions.yml`, and `config/dependabot/npm-actions-no-octokit.yml` to make dependency update commits more identifiable. [[1]](diffhunk://#diff-224826beeb54245dd3fd8e2714f48782d22d55a98924a4d24de351b3e2193d3dL13-R13) [[2]](diffhunk://#diff-8650615fbc004cd73a5b97bec74912b4b5e737b618a1f406dfce4ec739d8db33L13-R13) [[3]](diffhunk://#diff-f7e8847854d6f407c2a44ce9e1e2fefdf85ad1c6f68bbc257c76968eee442fe9L13-R13)

Npm update strategy enhancements:

* Added `versioning-strategy: increase` to the npm update configuration in `config/dependabot/npm-actions.yml` and `config/dependabot/npm-actions-no-octokit.yml` to ensure that dependency versions are incremented rather than replaced. [[1]](diffhunk://#diff-8650615fbc004cd73a5b97bec74912b4b5e737b618a1f406dfce4ec739d8db33R23-R26) [[2]](diffhunk://#diff-f7e8847854d6f407c2a44ce9e1e2fefdf85ad1c6f68bbc257c76968eee442fe9R23-R26)
* Included the `scope` in the commit message for npm updates by adding `include: 'scope'` to the configuration, providing more context in commit messages. [[1]](diffhunk://#diff-8650615fbc004cd73a5b97bec74912b4b5e737b618a1f406dfce4ec739d8db33R23-R26) [[2]](diffhunk://#diff-f7e8847854d6f407c2a44ce9e1e2fefdf85ad1c6f68bbc257c76968eee442fe9R23-R26)