### PR TITLE
feat: add ruleset configuration for CI actions in repos.yml

### DIFF
--- a/config/rulesets/actions-ci.json
+++ b/config/rulesets/actions-ci.json
@@ -1,0 +1,51 @@
+{
+  "id": 9620349,
+  "name": "ci",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "joshjohanning/ensure-immutable-actions",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "test",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "copilot_code_review",
+      "parameters": {
+        "review_on_push": false,
+        "review_draft_pull_requests": false
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/repos.yml
+++ b/repos.yml
@@ -12,6 +12,7 @@ repos:
   - repo: joshjohanning/nodejs-actions-starter-template
     topics: 'github,actions,javascript,node-action'
     dependabot-yml: './config/dependabot/npm-actions.yml'
+    rulesets-file: './config/rulesets/actions-ci.json'
   - repo: joshjohanning/npm-version-check-action
     topics: 'github,actions,javascript,node-action'
     dependabot-yml: './config/dependabot/npm-actions.yml'
@@ -21,6 +22,7 @@ repos:
   - repo: joshjohanning/twistlock-results-json-to-markdown-action
     topics: 'github,actions,javascript,node-action,prisma,twistlock'
     dependabot-yml: './config/dependabot/npm-actions.yml'
+    rulesets-file: './config/rulesets/actions-ci.json'
   - repo: joshjohanning/publish-github-action
     topics: 'github,actions,javascript,node-action'
     dependabot-yml: './config/dependabot/npm-actions.yml'


### PR DESCRIPTION
This pull request adds a new branch protection ruleset for CI enforcement and applies it to two repositories in the monorepo configuration. The ruleset introduces stricter controls on branch changes and required status checks for CI workflows.