### PR TITLE
test: update dependabot

### DIFF
--- a/config/dependabot/npm-actions-no-octokit.yml
+++ b/config/dependabot/npm-actions-no-octokit.yml
@@ -23,7 +23,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: 'tuesday'
       time: '05:00'
       timezone: 'America/Chicago'
     versioning-strategy: 'increase'

--- a/config/dependabot/npm-actions.yml
+++ b/config/dependabot/npm-actions.yml
@@ -23,7 +23,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: 'tuesday'
       time: '05:00'
       timezone: 'America/Chicago'
     versioning-strategy: 'increase'


### PR DESCRIPTION
This pull request updates the Dependabot configuration to change the weekly update schedule from Monday to Tuesday for both `npm-actions` and `npm-actions-no-octokit` workflows.