### PR TITLE
feat: add bulk GitHub org settings sync action

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -109,6 +109,14 @@ repos:
       - ./config/workflows/publish.yml
     gitignore: './config/gitignore/.gitignore-actions'
     copilot-instructions-md: './config/copilot/copilot-instructions-actions.md'
+  - repo: joshjohanning/bulk-github-org-settings-sync-action
+    topics: 'github,actions,javascript,node-action,approval,issueops,issue-ops'
+    dependabot-yml: './config/dependabot/npm-actions.yml'
+    rulesets-file: './config/rulesets/actions-ci.json'
+    immutable-releases: true
+    workflow-files:
+      - ./config/workflows/ci.yml
+      - ./config/workflows/publish.yml
 
   # node actions (typescript)
   - repo: joshjohanning/generate-org-repos-sbom-action


### PR DESCRIPTION
This pull request adds configuration for the `joshjohanning/bulk-github-org-settings-sync-action` repository to the `repos.yml` file. The configuration specifies repository topics, dependabot settings, rulesets, workflow files, and marks releases as immutable.