### PR TITLE
feat: add gitignore and copilot instructions for actions in repos.yml

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -117,6 +117,8 @@ repos:
     workflow-files:
       - ./config/workflows/ci.yml
       - ./config/workflows/publish.yml
+    gitignore: './config/gitignore/.gitignore-actions'
+    copilot-instructions-md: './config/copilot/copilot-instructions-actions.md'
 
   # node actions (typescript)
   - repo: joshjohanning/generate-org-repos-sbom-action


### PR DESCRIPTION
This pull request makes a small update to the `repos.yml` configuration file by adding new entries for `gitignore` and `copilot-instructions-md` under the `repos` section. These entries specify the paths to the respective configuration files for gitignore and Copilot instructions.