### PR TITLE
fix(deps): remove cooldown from Dependabot configuration

### DIFF
--- a/config/dependabot/actions-npm-security-grouped.yml
+++ b/config/dependabot/actions-npm-security-grouped.yml
@@ -14,8 +14,6 @@ updates:
       timezone: 'America/Chicago'
     commit-message:
       prefix: 'ci(deps)'
-    cooldown:
-      default-days: 3
     groups:
       github-actions:
         patterns:

--- a/config/dependabot/actions.yml
+++ b/config/dependabot/actions.yml
@@ -14,8 +14,6 @@ updates:
       timezone: 'America/Chicago'
     commit-message:
       prefix: 'ci(deps)'
-    cooldown:
-      default-days: 3
     groups:
       github-actions:
         patterns:

--- a/config/dependabot/npm-actions-no-octokit.yml
+++ b/config/dependabot/npm-actions-no-octokit.yml
@@ -14,8 +14,6 @@ updates:
       timezone: 'America/Chicago'
     commit-message:
       prefix: 'ci(deps)'
-    cooldown:
-      default-days: 3
     groups:
       github-actions:
         patterns:

--- a/config/dependabot/npm-actions.yml
+++ b/config/dependabot/npm-actions.yml
@@ -14,8 +14,6 @@ updates:
       timezone: 'America/Chicago'
     commit-message:
       prefix: 'ci(deps)'
-    cooldown:
-      default-days: 3
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
This pull request removes the default cooldown period for Dependabot updates in several configuration files. The cooldown setting previously delayed updates by three days, but with its removal, updates may be created more frequently.