### PR TITLE
chore: upgrade actions/create-github-app-token to v3, use client-id

### DIFF
--- a/.github/workflows/check-draft-releases.yml
+++ b/.github/workflows/check-draft-releases.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/sync-github-repo-settings.yml
+++ b/.github/workflows/sync-github-repo-settings.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Summary

Upgrades `actions/create-github-app-token` to `@v3` and migrates from the deprecated `app-id` input to `client-id`.

### Changes
- ⬆️ Updated `actions/create-github-app-token` to `@v3`
- 🔄 Renamed input from `app-id` to `client-id` ([v3 changelog](https://github.com/actions/create-github-app-token/releases/tag/v3.0.0))
- 📝 Renamed variable references to use `*_CLIENT_ID` naming

### ✅ Variable Updates
- New variable(s) created: `APP_CLIENT_ID`
- Workflow updated to reference the new variable(s)

### 🧹 After Merging
Delete the old variable(s) that are no longer referenced: `APP_ID`