### PR TITLE
fix(deps): update dependabot configuration for live test action

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -174,4 +174,4 @@ repos:
     immutable-releases: true
   - repo: joshjohanning/bulk-github-repo-settings-sync-action-live-tests
     topics: 'github,github-settings,settings-sync'
-    dependabot-yml: './config/dependabot/actions.yml'
+    dependabot-yml: './config/dependabot/npm-actions-no-octokit.yml'


### PR DESCRIPTION
This pull request updates the Dependabot configuration for the `joshjohanning/bulk-github-repo-settings-sync-action-live-tests` repository to use a different YAML file for its settings.