### PR TITLE
feat: adding org sync and update topics

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -12,7 +12,7 @@ repos:
     copilot-instructions-md: './config/copilot/copilot-instructions-actions.md'
     package-json-file: './config/package-json/package.json'
   - repo: joshjohanning/bulk-github-repo-settings-sync-action
-    topics: 'github,actions,javascript,node-action'
+    topics: 'github,actions,javascript,node-action,github-settings,settings-sync,github-config-as-code'
     dependabot-yml: './config/dependabot/npm-actions.yml'
     rulesets-file: './config/rulesets/actions-ci.json'
     immutable-releases: true
@@ -110,7 +110,7 @@ repos:
     gitignore: './config/gitignore/.gitignore-actions'
     copilot-instructions-md: './config/copilot/copilot-instructions-actions.md'
   - repo: joshjohanning/bulk-github-org-settings-sync-action
-    topics: 'github,actions,javascript,node-action,approval,issueops,issue-ops'
+    topics: 'github,actions,javascript,node-action,github-settings,settings-sync,github-config-as-code'
     dependabot-yml: './config/dependabot/npm-actions.yml'
     rulesets-file: './config/rulesets/actions-ci.json'
     immutable-releases: true
@@ -140,10 +140,13 @@ repos:
 
   # other repositories
   - repo: joshjohanning/sync-github-repo-settings
-    topics: 'github,github-settings,settings-sync'
+    topics: 'github,github-settings,settings-sync,github-config-as-code'
     dependabot-yml: './config/dependabot/actions.yml'
     gitignore: './config/gitignore/.gitignore-simple'
-
+  - repo: joshjohanning/sync-github-org-settings
+    topics: 'github,github-settings,settings-sync,github-config-as-code'
+    dependabot-yml: './config/dependabot/actions.yml'
+    gitignore: './config/gitignore/.gitignore-simple'
   - repo: joshjohanning/hsa-expense-analyzer-cli
     dependabot-yml: './config/dependabot/npm-actions-no-octokit.yml'
     immutable-releases: true


### PR DESCRIPTION
**Repository metadata improvements:**

* Expanded the `topics` fields for `joshjohanning/bulk-github-repo-settings-sync-action`, `joshjohanning/bulk-github-org-settings-sync-action`, `joshjohanning/sync-github-repo-settings`, and added `github-config-as-code` to better reflect repository functionality and improve searchability. [[1]](diffhunk://#diff-360c9f8337f35b474ac3e370aeef219c9f6dfdbad8417946d236c6b4f2dfc50dL15-R15) [[2]](diffhunk://#diff-360c9f8337f35b474ac3e370aeef219c9f6dfdbad8417946d236c6b4f2dfc50dL113-R113) [[3]](diffhunk://#diff-360c9f8337f35b474ac3e370aeef219c9f6dfdbad8417946d236c6b4f2dfc50dL143-L146)

**Configuration enhancements:**

* Added `dependabot-yml` and `gitignore` configuration entries for `joshjohanning/sync-github-repo-settings` and `joshjohanning/sync-github-org-settings` to ensure consistent dependency management and ignore settings.