### PR TITLE
feat: add todo repo

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -194,3 +194,6 @@ repos:
     rulesets-file: './config/rulesets/ccr-only.json'
   - repo: joshjohanning/joshjohanning
     rulesets-file: './config/rulesets/ccr-only.json'
+  - repo: joshjohanning/todo
+    dependabot-yml: './config/dependabot/npm-actions-no-octokit.yml'
+    rulesets-file: './config/rulesets/ccr-only.json'


### PR DESCRIPTION
This pull request adds configuration for the `joshjohanning/todo` repository, specifying custom Dependabot and ruleset files.

Repository configuration updates:

* Added `joshjohanning/todo` to the list of managed repositories in `repos.yml`, with a specific Dependabot configuration (`dependabot/npm-actions-no-octokit.yml`) and ruleset (`ccr-only.json`).