### PR TITLE
ci(deps): upgrade actions/checkout from v6 to v7 in CI and publish workflows

### DIFF
--- a/config/workflows/ci.yml
+++ b/config/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/config/workflows/publish.yml
+++ b/config/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: joshjohanning/publish-github-action@v3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use the latest version of the `actions/checkout` action in both the CI and publish workflows.

Workflow dependency updates:

* Updated the `actions/checkout` action from version `v6` to `v7` in the `ci.yml` workflow file.
* Updated the `actions/checkout` action from version `v6` to `v7` in the `publish.yml` workflow file.