### PR TITLE
feat(todo): disable code and secret scanning for todo repo

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -196,4 +196,7 @@ repos:
     rulesets-file: './config/rulesets/ccr-only.json'
   - repo: joshjohanning/todo
     dependabot-yml: './config/dependabot/npm-actions-no-octokit.yml'
+    code-scanning: false
+    secret-scanning: false
+    secret-scanning-push-protection: false
     rulesets-file: './config/rulesets/ccr-only.json'


### PR DESCRIPTION
This pull request makes a minor update to the configuration for the `joshjohanning/todo` repository, disabling several scanning features.

- Disabled code scanning, secret scanning, and secret scanning push protection for the `joshjohanning/todo` repository in `repos.yml`.