### PR TITLE
ci(deps): upgrade actions/setup-node from v6 to v7

### DIFF
--- a/config/workflows/ci.yml
+++ b/config/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'npm'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the Node.js setup action.

Workflow dependency update:

* Updated the Node.js setup action from `actions/setup-node@v6` to `actions/setup-node@v7` in `config/workflows/ci.yml` to ensure the workflow uses the latest features and security updates.